### PR TITLE
Initialize React skeleton with Vercel API stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# elevator-sim
-An academic proof-of-concept implementing an Agile OO-Clean-DDD methodology end-to-end
+# Elevator Simulation
+
+This project is a simple skeleton for a 5‑floor elevator control system using React and Vercel serverless APIs.
+
+## Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm run dev
+```
+
+## Deployment
+
+Deploy the project on Vercel using the Vercel CLI or through the Vercel dashboard.

--- a/api/call.js
+++ b/api/call.js
@@ -1,0 +1,4 @@
+export default function handler(req, res) {
+    // TODO: handle elevator call
+    res.status(200).json({});
+}

--- a/api/tick.js
+++ b/api/tick.js
@@ -1,0 +1,4 @@
+export default function handler(req, res) {
+    // TODO: handle simulation tick
+    res.status(200).json({});
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "elevator-sim",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vercel dev",
+    "build": "vercel build"
+  },
+  "dependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Elevator Simulation</title>
+</head>
+<body>
+    <div id="root"></div>
+    <script src="../src/index.js"></script>
+</body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ElevatorSimulation from './components/ElevatorSimulation';
+
+export default function App() {
+    return <ElevatorSimulation />;
+}

--- a/src/components/ElevatorSimulation.js
+++ b/src/components/ElevatorSimulation.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function ElevatorSimulation() {
+    return <div />;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
## Summary
- setup React/Vercel project skeleton
- add empty ElevatorSimulation component
- add serverless stubs for call and tick
- document development and deployment commands

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6886b907e3cc8333a890e47bf120f091