### PR TITLE
Add infrastructure adapter skeletons

### DIFF
--- a/__tests__/infrastructure/CallRequestRepositoryMemory.test.js
+++ b/__tests__/infrastructure/CallRequestRepositoryMemory.test.js
@@ -1,0 +1,15 @@
+const CallRequestRepositoryMemory = require('../../infrastructure/CallRequestRepositoryMemory');
+const CallRequestRepository = require('../../application/ports/CallRequestRepository');
+
+describe('CallRequestRepositoryMemory', () => {
+  test('extends CallRequestRepository', () => {
+    const repo = new CallRequestRepositoryMemory();
+    expect(repo instanceof CallRequestRepository).toBe(true);
+  });
+
+  test('methods throw Not implemented', async () => {
+    const repo = new CallRequestRepositoryMemory();
+    await expect(repo.enqueue({})).rejects.toThrow('Not implemented');
+    await expect(repo.dequeueAll()).rejects.toThrow('Not implemented');
+  });
+});

--- a/__tests__/infrastructure/DestinationRequestRepositoryMemory.test.js
+++ b/__tests__/infrastructure/DestinationRequestRepositoryMemory.test.js
@@ -1,0 +1,15 @@
+const DestinationRequestRepositoryMemory = require('../../infrastructure/DestinationRequestRepositoryMemory');
+const DestinationRequestRepository = require('../../application/ports/DestinationRequestRepository');
+
+describe('DestinationRequestRepositoryMemory', () => {
+  test('extends DestinationRequestRepository', () => {
+    const repo = new DestinationRequestRepositoryMemory();
+    expect(repo instanceof DestinationRequestRepository).toBe(true);
+  });
+
+  test('methods throw Not implemented', async () => {
+    const repo = new DestinationRequestRepositoryMemory();
+    await expect(repo.enqueue({})).rejects.toThrow('Not implemented');
+    await expect(repo.dequeueAll()).rejects.toThrow('Not implemented');
+  });
+});

--- a/__tests__/infrastructure/ElevatorRepositoryHttp.test.js
+++ b/__tests__/infrastructure/ElevatorRepositoryHttp.test.js
@@ -1,0 +1,16 @@
+const ElevatorRepositoryHttp = require('../../infrastructure/ElevatorRepositoryHttp');
+const ElevatorRepository = require('../../application/ports/ElevatorRepository');
+
+describe('ElevatorRepositoryHttp', () => {
+  test('extends ElevatorRepository', () => {
+    const repo = new ElevatorRepositoryHttp();
+    expect(repo instanceof ElevatorRepository).toBe(true);
+  });
+
+  test('methods throw Not implemented', async () => {
+    const repo = new ElevatorRepositoryHttp();
+    await expect(repo.findAll()).rejects.toThrow('Not implemented');
+    await expect(repo.findById('id')).rejects.toThrow('Not implemented');
+    await expect(repo.save({})).rejects.toThrow('Not implemented');
+  });
+});

--- a/__tests__/infrastructure/EventPublisherConsole.test.js
+++ b/__tests__/infrastructure/EventPublisherConsole.test.js
@@ -1,0 +1,14 @@
+const EventPublisherConsole = require('../../infrastructure/EventPublisherConsole');
+const EventPublisher = require('../../application/ports/EventPublisher');
+
+describe('EventPublisherConsole', () => {
+  test('extends EventPublisher', () => {
+    const pub = new EventPublisherConsole();
+    expect(pub instanceof EventPublisher).toBe(true);
+  });
+
+  test('publish throws Not implemented', async () => {
+    const pub = new EventPublisherConsole();
+    await expect(pub.publish({})).rejects.toThrow('Not implemented');
+  });
+});

--- a/__tests__/infrastructure/TimeProviderSystem.test.js
+++ b/__tests__/infrastructure/TimeProviderSystem.test.js
@@ -1,0 +1,14 @@
+const TimeProviderSystem = require('../../infrastructure/TimeProviderSystem');
+const TimeProvider = require('../../application/ports/TimeProvider');
+
+describe('TimeProviderSystem', () => {
+  test('extends TimeProvider', () => {
+    const tp = new TimeProviderSystem();
+    expect(tp instanceof TimeProvider).toBe(true);
+  });
+
+  test('now throws Not implemented', () => {
+    const tp = new TimeProviderSystem();
+    expect(() => tp.now()).toThrow('Not implemented');
+  });
+});

--- a/infrastructure/CallRequestRepositoryMemory.js
+++ b/infrastructure/CallRequestRepositoryMemory.js
@@ -1,0 +1,14 @@
+// infrastructure/CallRequestRepositoryMemory.js
+const CallRequestRepository = require('../application/ports/CallRequestRepository');
+
+class CallRequestRepositoryMemory extends CallRequestRepository {
+  async enqueue(request) {
+    throw new Error('Not implemented');
+  }
+
+  async dequeueAll() {
+    throw new Error('Not implemented');
+  }
+}
+
+module.exports = CallRequestRepositoryMemory;

--- a/infrastructure/DestinationRequestRepositoryMemory.js
+++ b/infrastructure/DestinationRequestRepositoryMemory.js
@@ -1,0 +1,14 @@
+// infrastructure/DestinationRequestRepositoryMemory.js
+const DestinationRequestRepository = require('../application/ports/DestinationRequestRepository');
+
+class DestinationRequestRepositoryMemory extends DestinationRequestRepository {
+  async enqueue(request) {
+    throw new Error('Not implemented');
+  }
+
+  async dequeueAll() {
+    throw new Error('Not implemented');
+  }
+}
+
+module.exports = DestinationRequestRepositoryMemory;

--- a/infrastructure/ElevatorRepositoryHttp.js
+++ b/infrastructure/ElevatorRepositoryHttp.js
@@ -1,0 +1,18 @@
+// infrastructure/ElevatorRepositoryHttp.js
+const ElevatorRepository = require('../application/ports/ElevatorRepository');
+
+class ElevatorRepositoryHttp extends ElevatorRepository {
+  async findAll() {
+    throw new Error('Not implemented');
+  }
+
+  async findById(id) {
+    throw new Error('Not implemented');
+  }
+
+  async save(elevator) {
+    throw new Error('Not implemented');
+  }
+}
+
+module.exports = ElevatorRepositoryHttp;

--- a/infrastructure/EventPublisherConsole.js
+++ b/infrastructure/EventPublisherConsole.js
@@ -1,0 +1,10 @@
+// infrastructure/EventPublisherConsole.js
+const EventPublisher = require('../application/ports/EventPublisher');
+
+class EventPublisherConsole extends EventPublisher {
+  async publish(event) {
+    throw new Error('Not implemented');
+  }
+}
+
+module.exports = EventPublisherConsole;

--- a/infrastructure/TimeProviderSystem.js
+++ b/infrastructure/TimeProviderSystem.js
@@ -1,0 +1,10 @@
+// infrastructure/TimeProviderSystem.js
+const TimeProvider = require('../application/ports/TimeProvider');
+
+class TimeProviderSystem extends TimeProvider {
+  now() {
+    throw new Error('Not implemented');
+  }
+}
+
+module.exports = TimeProviderSystem;


### PR DESCRIPTION
## Summary
- scaffold adapter classes in `infrastructure/`
- each adapter extends the corresponding application port and throws `Not implemented`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688703750ad883339d009868310af019