### PR TITLE
Implement in-memory infrastructure classes

### DIFF
--- a/__tests__/infrastructure/CallRequestRepositoryMemory.test.js
+++ b/__tests__/infrastructure/CallRequestRepositoryMemory.test.js
@@ -7,9 +7,15 @@ describe('CallRequestRepositoryMemory', () => {
     expect(repo instanceof CallRequestRepository).toBe(true);
   });
 
-  test('methods throw Not implemented', async () => {
+  test('enqueue and dequeueAll store and clear requests', async () => {
     const repo = new CallRequestRepositoryMemory();
-    await expect(repo.enqueue({})).rejects.toThrow('Not implemented');
-    await expect(repo.dequeueAll()).rejects.toThrow('Not implemented');
+    const req1 = { id: 1 };
+    const req2 = { id: 2 };
+    await repo.enqueue(req1);
+    await repo.enqueue(req2);
+    const all = await repo.dequeueAll();
+    expect(all).toEqual([req1, req2]);
+    const empty = await repo.dequeueAll();
+    expect(empty).toEqual([]);
   });
 });

--- a/__tests__/infrastructure/DestinationRequestRepositoryMemory.test.js
+++ b/__tests__/infrastructure/DestinationRequestRepositoryMemory.test.js
@@ -7,9 +7,15 @@ describe('DestinationRequestRepositoryMemory', () => {
     expect(repo instanceof DestinationRequestRepository).toBe(true);
   });
 
-  test('methods throw Not implemented', async () => {
+  test('enqueue and dequeueAll store and clear requests', async () => {
     const repo = new DestinationRequestRepositoryMemory();
-    await expect(repo.enqueue({})).rejects.toThrow('Not implemented');
-    await expect(repo.dequeueAll()).rejects.toThrow('Not implemented');
+    const req1 = { id: 1 };
+    const req2 = { id: 2 };
+    await repo.enqueue(req1);
+    await repo.enqueue(req2);
+    const all = await repo.dequeueAll();
+    expect(all).toEqual([req1, req2]);
+    const empty = await repo.dequeueAll();
+    expect(empty).toEqual([]);
   });
 });

--- a/__tests__/infrastructure/ElevatorRepositoryHttp.test.js
+++ b/__tests__/infrastructure/ElevatorRepositoryHttp.test.js
@@ -7,10 +7,15 @@ describe('ElevatorRepositoryHttp', () => {
     expect(repo instanceof ElevatorRepository).toBe(true);
   });
 
-  test('methods throw Not implemented', async () => {
+  test('can save and retrieve elevators', async () => {
     const repo = new ElevatorRepositoryHttp();
-    await expect(repo.findAll()).rejects.toThrow('Not implemented');
-    await expect(repo.findById('id')).rejects.toThrow('Not implemented');
-    await expect(repo.save({})).rejects.toThrow('Not implemented');
+    const e1 = { id: 'E1' };
+    const e2 = { id: 'E2' };
+    await repo.save(e1);
+    await repo.save(e2);
+    const all = await repo.findAll();
+    expect(all).toEqual([e1, e2]);
+    const found = await repo.findById('E1');
+    expect(found).toBe(e1);
   });
 });

--- a/__tests__/infrastructure/EventPublisherConsole.test.js
+++ b/__tests__/infrastructure/EventPublisherConsole.test.js
@@ -7,8 +7,12 @@ describe('EventPublisherConsole', () => {
     expect(pub instanceof EventPublisher).toBe(true);
   });
 
-  test('publish throws Not implemented', async () => {
+  test('publish logs the event', async () => {
     const pub = new EventPublisherConsole();
-    await expect(pub.publish({})).rejects.toThrow('Not implemented');
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const event = { type: 'TEST' };
+    await pub.publish(event);
+    expect(spy).toHaveBeenCalledWith(event);
+    spy.mockRestore();
   });
 });

--- a/__tests__/infrastructure/TimeProviderSystem.test.js
+++ b/__tests__/infrastructure/TimeProviderSystem.test.js
@@ -7,8 +7,13 @@ describe('TimeProviderSystem', () => {
     expect(tp instanceof TimeProvider).toBe(true);
   });
 
-  test('now throws Not implemented', () => {
+  test('now returns current timestamp', () => {
     const tp = new TimeProviderSystem();
-    expect(() => tp.now()).toThrow('Not implemented');
+    const before = Date.now();
+    const value = tp.now();
+    const after = Date.now();
+    expect(typeof value).toBe('number');
+    expect(value).toBeGreaterThanOrEqual(before);
+    expect(value).toBeLessThanOrEqual(after);
   });
 });

--- a/infrastructure/CallRequestRepositoryMemory.js
+++ b/infrastructure/CallRequestRepositoryMemory.js
@@ -2,12 +2,19 @@
 const CallRequestRepository = require('../application/ports/CallRequestRepository');
 
 class CallRequestRepositoryMemory extends CallRequestRepository {
+  constructor() {
+    super();
+    this.queue = [];
+  }
+
   async enqueue(request) {
-    throw new Error('Not implemented');
+    this.queue.push(request);
   }
 
   async dequeueAll() {
-    throw new Error('Not implemented');
+    const all = [...this.queue];
+    this.queue = [];
+    return all;
   }
 }
 

--- a/infrastructure/DestinationRequestRepositoryMemory.js
+++ b/infrastructure/DestinationRequestRepositoryMemory.js
@@ -2,12 +2,19 @@
 const DestinationRequestRepository = require('../application/ports/DestinationRequestRepository');
 
 class DestinationRequestRepositoryMemory extends DestinationRequestRepository {
+  constructor() {
+    super();
+    this.queue = [];
+  }
+
   async enqueue(request) {
-    throw new Error('Not implemented');
+    this.queue.push(request);
   }
 
   async dequeueAll() {
-    throw new Error('Not implemented');
+    const all = [...this.queue];
+    this.queue = [];
+    return all;
   }
 }
 

--- a/infrastructure/ElevatorRepositoryHttp.js
+++ b/infrastructure/ElevatorRepositoryHttp.js
@@ -2,16 +2,24 @@
 const ElevatorRepository = require('../application/ports/ElevatorRepository');
 
 class ElevatorRepositoryHttp extends ElevatorRepository {
+  constructor(initialElevators = []) {
+    super();
+    this.elevators = new Map();
+    for (const e of initialElevators) {
+      this.elevators.set(e.id, e);
+    }
+  }
+
   async findAll() {
-    throw new Error('Not implemented');
+    return Array.from(this.elevators.values());
   }
 
   async findById(id) {
-    throw new Error('Not implemented');
+    return this.elevators.get(id);
   }
 
   async save(elevator) {
-    throw new Error('Not implemented');
+    this.elevators.set(elevator.id, elevator);
   }
 }
 

--- a/infrastructure/EventPublisherConsole.js
+++ b/infrastructure/EventPublisherConsole.js
@@ -3,7 +3,7 @@ const EventPublisher = require('../application/ports/EventPublisher');
 
 class EventPublisherConsole extends EventPublisher {
   async publish(event) {
-    throw new Error('Not implemented');
+    console.log(event);
   }
 }
 

--- a/infrastructure/TimeProviderSystem.js
+++ b/infrastructure/TimeProviderSystem.js
@@ -3,7 +3,7 @@ const TimeProvider = require('../application/ports/TimeProvider');
 
 class TimeProviderSystem extends TimeProvider {
   now() {
-    throw new Error('Not implemented');
+    return Date.now();
   }
 }
 


### PR DESCRIPTION
## Summary
- make memory-based CallRequestRepository and DestinationRequestRepository
- make a simple in-memory ElevatorRepository
- implement console event publisher and system time provider
- update tests for these working implementations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688711641b0483338524a4d2172689b5