### PR TITLE
Support multiple elevators with building aggregate

### DIFF
--- a/__tests__/domain/entities/Building.test.js
+++ b/__tests__/domain/entities/Building.test.js
@@ -1,0 +1,31 @@
+const Building = require('../../../domain/entities/Building');
+const Elevator = require('../../../domain/entities/Elevator');
+const CallRequest = require('../../../domain/entities/CallRequest');
+const DestinationRequest = require('../../../domain/entities/DestinationRequest');
+const ElevatorState = require('../../../domain/valueobjects/ElevatorState');
+
+describe('Building', () => {
+  test('assigns call to closest elevator considering direction', () => {
+    const e1 = new Elevator('E1', 1);
+    const e2 = new Elevator('E2', 5);
+    e1.state = new ElevatorState('Idle');
+    e2.state = new ElevatorState('Idle');
+    const building = new Building([e1, e2]);
+
+    building.handleCall(new CallRequest(4, 'Down'));
+
+    expect(e2.targetFloors[0].value).toBe(4);
+    expect(e1.targetFloors).toHaveLength(0);
+  });
+
+  test('assigns destination to nearest elevator', () => {
+    const e1 = new Elevator('E1', 1);
+    const e2 = new Elevator('E2', 5);
+    const building = new Building([e1, e2]);
+
+    building.handleDestination(new DestinationRequest(2));
+
+    expect(e1.targetFloors[0].value).toBe(2);
+    expect(e2.targetFloors).toHaveLength(0);
+  });
+});

--- a/__tests__/domain/services/ElevatorDispatcher.multi.test.js
+++ b/__tests__/domain/services/ElevatorDispatcher.multi.test.js
@@ -1,0 +1,38 @@
+const ElevatorDispatcher = require('../../../domain/services/ElevatorDispatcher');
+const CallRequest = require('../../../domain/entities/CallRequest');
+const DestinationRequest = require('../../../domain/entities/DestinationRequest');
+const Elevator = require('../../../domain/entities/Elevator');
+const ElevatorState = require('../../../domain/valueobjects/ElevatorState');
+
+describe('ElevatorDispatcher with multiple elevators', () => {
+  test('dispatches requests to nearest elevators', async () => {
+    const e1 = new Elevator('E1', 1);
+    const e2 = new Elevator('E2', 5);
+    e1.state = new ElevatorState('Idle');
+    e2.state = new ElevatorState('Idle');
+
+    const elevatorRepo = {
+      findAll: jest.fn().mockResolvedValue([e1, e2]),
+      save: jest.fn()
+    };
+
+    const callRepo = {
+      dequeueAll: jest.fn().mockResolvedValue([new CallRequest(4, 'Down')]),
+      enqueue: jest.fn()
+    };
+
+    const destRepo = {
+      dequeueAll: jest.fn().mockResolvedValue([new DestinationRequest(2)]),
+      enqueue: jest.fn()
+    };
+
+    const dispatcher = new ElevatorDispatcher(elevatorRepo, callRepo, destRepo);
+
+    await dispatcher.handleTick({ now: () => Date.now() });
+
+    expect(e2.targetFloors[0].value).toBe(4);
+    expect(e1.targetFloors[0].value).toBe(2);
+    expect(elevatorRepo.save).toHaveBeenCalledWith(e1);
+    expect(elevatorRepo.save).toHaveBeenCalledWith(e2);
+  });
+});

--- a/domain/entities/Building.js
+++ b/domain/entities/Building.js
@@ -1,0 +1,62 @@
+const FloorNumber = require('../valueobjects/FloorNumber');
+const Direction = require('../valueobjects/Direction');
+
+class Building {
+  constructor(elevators = []) {
+    this.elevators = elevators;
+  }
+
+  addElevator(elevator) {
+    this.elevators.push(elevator);
+  }
+
+  getElevators() {
+    return this.elevators;
+  }
+
+  findBestElevator(floor, direction) {
+    const target = floor instanceof FloorNumber ? floor : new FloorNumber(floor);
+    let best = null;
+    let bestScore = Infinity;
+
+    for (const elevator of this.elevators) {
+      let score = Math.abs(elevator.currentFloor.value - target.value);
+      const state = elevator.state.value;
+
+      if (direction instanceof Direction) {
+        if (state === 'MovingUp') {
+          if (!(direction.value === 'Up' && elevator.currentFloor.value <= target.value)) {
+            score += 1000;
+          }
+        } else if (state === 'MovingDown') {
+          if (!(direction.value === 'Down' && elevator.currentFloor.value >= target.value)) {
+            score += 1000;
+          }
+        }
+      }
+
+      if (score < bestScore) {
+        bestScore = score;
+        best = elevator;
+      }
+    }
+
+    return best;
+  }
+
+  handleCall(callRequest) {
+    const elevator = this.findBestElevator(callRequest.floor, callRequest.direction);
+    if (elevator) {
+      elevator.addDestination(callRequest.floor);
+    }
+  }
+
+  handleDestination(destRequest) {
+    const elevator = this.findBestElevator(destRequest.floor);
+    if (elevator) {
+      elevator.addDestination(destRequest.floor);
+    }
+  }
+}
+
+module.exports = Building;


### PR DESCRIPTION
## Summary
- add Building aggregate to select nearest elevator
- extend ElevatorDispatcher to use Building for routing
- test new Building behavior
- test dispatcher with multiple elevators

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6887152a8980833387ec32c49c7c7b37