### PR TITLE
Use dispatcher and publish events in handlers

### DIFF
--- a/__tests__/application/HandleDestinationRequest.test.js
+++ b/__tests__/application/HandleDestinationRequest.test.js
@@ -2,15 +2,15 @@ const HandleDestinationRequest = require('../../application/HandleDestinationReq
 const DestinationRequest = require('../../domain/entities/DestinationRequest');
 
 describe('HandleDestinationRequest', () => {
-  test('enqueues destination and saves elevator when applicable', async () => {
-    const mockDestRepo = { enqueue: jest.fn() };
-    const mockElevatorRepo = { save: jest.fn() };
-    const handler = new HandleDestinationRequest(mockDestRepo, mockElevatorRepo);
+  test('dispatches destination through dispatcher and publishes event', async () => {
+    const dispatcher = { dispatchDestination: jest.fn() };
+    const publisher = { publish: jest.fn() };
+    const handler = new HandleDestinationRequest(dispatcher, publisher);
     const req = new DestinationRequest(5);
 
     await handler.execute(req);
 
-    expect(mockDestRepo.enqueue).toHaveBeenCalledWith(req);
-    expect(mockElevatorRepo.save).toHaveBeenCalled();
+    expect(dispatcher.dispatchDestination).toHaveBeenCalledWith(req);
+    expect(publisher.publish).toHaveBeenCalledWith({ type: 'DestinationQueued', request: req });
   });
 });

--- a/__tests__/application/HandleExternalCall.test.js
+++ b/__tests__/application/HandleExternalCall.test.js
@@ -2,15 +2,15 @@ const HandleExternalCall = require('../../application/HandleExternalCall');
 const CallRequest = require('../../domain/entities/CallRequest');
 
 describe('HandleExternalCall', () => {
-  test('enqueues request and saves elevator if assigned immediately', async () => {
-    const mockCallRepo = { enqueue: jest.fn() };
-    const mockElevatorRepo = { save: jest.fn() };
-    const handler = new HandleExternalCall(mockCallRepo, mockElevatorRepo);
+  test('dispatches call through dispatcher and publishes event', async () => {
+    const dispatcher = { dispatchCall: jest.fn() };
+    const publisher = { publish: jest.fn() };
+    const handler = new HandleExternalCall(dispatcher, publisher);
     const req = new CallRequest(3, 'Up');
 
     await handler.execute(req);
 
-    expect(mockCallRepo.enqueue).toHaveBeenCalledWith(req);
-    expect(mockElevatorRepo.save).toHaveBeenCalled();
+    expect(dispatcher.dispatchCall).toHaveBeenCalledWith(req);
+    expect(publisher.publish).toHaveBeenCalledWith({ type: 'CallQueued', request: req });
   });
 });

--- a/application/HandleDestinationRequest.js
+++ b/application/HandleDestinationRequest.js
@@ -1,15 +1,17 @@
 class HandleDestinationRequest {
-    constructor(destinationRepository, elevatorRepository) {
-      this.destinationRepository = destinationRepository;
-      this.elevatorRepository = elevatorRepository;
+  constructor(dispatcher, eventPublisher) {
+    this.dispatcher = dispatcher;
+    this.eventPublisher = eventPublisher;
+  }
+
+  async execute(request) {
+    if (this.dispatcher && typeof this.dispatcher.dispatchDestination === 'function') {
+      await this.dispatcher.dispatchDestination(request);
     }
-  
-    async execute(request) {
-      await this.destinationRepository.enqueue(request);
-      if (typeof this.elevatorRepository.save === 'function') {
-        await this.elevatorRepository.save();
-      }
+    if (this.eventPublisher && typeof this.eventPublisher.publish === 'function') {
+      await this.eventPublisher.publish({ type: 'DestinationQueued', request });
     }
   }
-  
-  module.exports = HandleDestinationRequest;
+}
+
+module.exports = HandleDestinationRequest;

--- a/application/HandleExternalCall.js
+++ b/application/HandleExternalCall.js
@@ -1,15 +1,17 @@
 class HandleExternalCall {
-    constructor(callRepository, elevatorRepository) {
-      this.callRepository = callRepository;
-      this.elevatorRepository = elevatorRepository;
+  constructor(dispatcher, eventPublisher) {
+    this.dispatcher = dispatcher;
+    this.eventPublisher = eventPublisher;
+  }
+
+  async execute(request) {
+    if (this.dispatcher && typeof this.dispatcher.dispatchCall === 'function') {
+      await this.dispatcher.dispatchCall(request);
     }
-  
-    async execute(request) {
-      await this.callRepository.enqueue(request);
-      if (typeof this.elevatorRepository.save === 'function') {
-        await this.elevatorRepository.save();
-      }
+    if (this.eventPublisher && typeof this.eventPublisher.publish === 'function') {
+      await this.eventPublisher.publish({ type: 'CallQueued', request });
     }
   }
-  
-  module.exports = HandleExternalCall;
+}
+
+module.exports = HandleExternalCall;

--- a/application/HandleTick.js
+++ b/application/HandleTick.js
@@ -1,37 +1,32 @@
 class HandleTick {
-    constructor(callRepo, destRepo, elevatorRepo, dispatcher, timeProvider) {
-      this.callRepo = callRepo;
-      this.destRepo = destRepo;
-      this.elevatorRepo = elevatorRepo;
-      this.dispatcher = dispatcher;
-      this.timeProvider = timeProvider;
+  constructor(dispatcher, eventPublisher, timeProvider) {
+    this.dispatcher = dispatcher;
+    this.eventPublisher = eventPublisher;
+    this.timeProvider = timeProvider;
+  }
+
+  async execute() {
+    if (this.dispatcher && typeof this.dispatcher.handleTick === 'function') {
+      await this.dispatcher.handleTick(this.timeProvider);
     }
-  
-    async execute() {
-      const calls = await this.callRepo.dequeueAll();
-      const destinations = await this.destRepo.dequeueAll();
-      const elevators = await this.elevatorRepo.findAll();
-  
-      if (this.dispatcher) {
-        for (const call of calls) {
-          if (typeof this.dispatcher.dispatchCall === 'function') {
-            await this.dispatcher.dispatchCall(call);
-          }
-        }
-        for (const dest of destinations) {
-          if (typeof this.dispatcher.dispatchDestination === 'function') {
-            await this.dispatcher.dispatchDestination(dest);
-          }
-        }
-      }
-  
+
+    const elevators = this.dispatcher && this.dispatcher.elevatorRepo
+      ? await this.dispatcher.elevatorRepo.findAll()
+      : [];
+
+    if (this.eventPublisher && typeof this.eventPublisher.publish === 'function') {
       for (const elevator of elevators) {
-        if (typeof elevator.move === 'function') {
-          elevator.move();
-        }
-        await this.elevatorRepo.save(elevator);
+        await this.eventPublisher.publish({
+          type: 'ElevatorUpdated',
+          id: elevator.id,
+          floor: elevator.currentFloor.value,
+          state: elevator.state.value,
+          targets: elevator.targetFloors.map(f => f.value),
+          timestamp: this.timeProvider.now(),
+        });
       }
     }
   }
-  
-  module.exports = HandleTick;
+}
+
+module.exports = HandleTick;


### PR DESCRIPTION
## Summary
- refactor `HandleExternalCall`, `HandleDestinationRequest` and `HandleTick` to use the dispatcher and publish events via `EventPublisher`
- update unit tests for the new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68871711cb448333959382f2a6fa05b4