### PR TITLE
Implement API request parsing and delegates

### DIFF
--- a/__tests__/api/call.test.js
+++ b/__tests__/api/call.test.js
@@ -1,0 +1,42 @@
+const api = require('../../api/call');
+const HandleExternalCall = require('../../application/HandleExternalCall');
+const CallRequest = require('../../domain/entities/CallRequest');
+
+jest.mock('../../application/HandleExternalCall');
+jest.mock('../../infrastructure/container', () => ({
+  callRepo: {},
+  elevatorRepo: {}
+}));
+
+function createRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis()
+  };
+}
+
+describe('api/call', () => {
+  test('parses body and delegates to HandleExternalCall', async () => {
+    const exec = jest.fn();
+    HandleExternalCall.mockImplementation(() => ({ execute: exec }));
+
+    const req = { method: 'POST', body: JSON.stringify({ floor: 2, direction: 'Up' }), on: jest.fn() };
+    const res = createRes();
+
+    await api(req, res);
+
+    expect(HandleExternalCall).toHaveBeenCalled();
+    expect(exec.mock.calls[0][0]).toBeInstanceOf(CallRequest);
+    expect(exec.mock.calls[0][0].floor.value).toBe(2);
+    expect(exec.mock.calls[0][0].direction.value).toBe('Up');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('returns 405 on invalid method', async () => {
+    const req = { method: 'GET', on: jest.fn() };
+    const res = createRes();
+
+    await api(req, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+});

--- a/__tests__/api/tick.test.js
+++ b/__tests__/api/tick.test.js
@@ -1,0 +1,43 @@
+const api = require('../../api/tick');
+const HandleTick = require('../../application/HandleTick');
+
+jest.mock('../../application/HandleTick');
+jest.mock('../../infrastructure/container', () => ({
+  callRepo: {},
+  destRepo: {},
+  elevatorRepo: {},
+  dispatcher: {},
+  timeProvider: {}
+}));
+
+function createRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis()
+  };
+}
+
+describe('api/tick', () => {
+  test('delegates to HandleTick', async () => {
+    const exec = jest.fn();
+    HandleTick.mockImplementation(() => ({ execute: exec }));
+
+    const req = { method: 'POST' };
+    const res = createRes();
+
+    await api(req, res);
+
+    expect(HandleTick).toHaveBeenCalled();
+    expect(exec).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('returns 405 on bad method', async () => {
+    const req = { method: 'PUT' };
+    const res = createRes();
+
+    await api(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+});

--- a/api/call.js
+++ b/api/call.js
@@ -1,4 +1,37 @@
-// api/call.js
+const HandleExternalCall = require('../application/HandleExternalCall');
+const CallRequest = require('../domain/entities/CallRequest');
+const { callRepo, elevatorRepo } = require('../infrastructure/container');
+
+async function parseBody(req) {
+  if (req.body) {
+    return typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+  }
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => { data += chunk; });
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
 module.exports = async (req, res) => {
-  res.status(200).json({ message: 'Not implemented.' });
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+  try {
+    const body = await parseBody(req);
+    const { floor, direction } = body;
+    const handler = new HandleExternalCall(callRepo, elevatorRepo);
+    await handler.execute(new CallRequest(floor, direction));
+    res.status(200).json({ status: 'ok' });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
 };

--- a/api/tick.js
+++ b/api/tick.js
@@ -1,4 +1,16 @@
-// api/tick.js
+const HandleTick = require('../application/HandleTick');
+const { callRepo, destRepo, elevatorRepo, dispatcher, timeProvider } = require('../infrastructure/container');
+
 module.exports = async (req, res) => {
-  res.status(200).json({ message: 'Not implemented.' });
+  if (req.method !== 'POST' && req.method !== 'GET') {
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+  try {
+    const handler = new HandleTick(callRepo, destRepo, elevatorRepo, dispatcher, timeProvider);
+    await handler.execute();
+    res.status(200).json({ status: 'ok' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 };

--- a/infrastructure/container.js
+++ b/infrastructure/container.js
@@ -1,0 +1,25 @@
+const Elevator = require('../domain/entities/Elevator');
+const CallRequestRepositoryMemory = require('./CallRequestRepositoryMemory');
+const DestinationRequestRepositoryMemory = require('./DestinationRequestRepositoryMemory');
+const ElevatorRepositoryHttp = require('./ElevatorRepositoryHttp');
+const ElevatorDispatcher = require('../domain/services/ElevatorDispatcher');
+const TimeProviderSystem = require('./TimeProviderSystem');
+
+// Singleton repositories and services to maintain state between requests
+const callRepo = new CallRequestRepositoryMemory();
+const destRepo = new DestinationRequestRepositoryMemory();
+const elevatorRepo = new ElevatorRepositoryHttp([
+  new Elevator('E1', 1),
+  new Elevator('E2', 5)
+]);
+
+const dispatcher = new ElevatorDispatcher(elevatorRepo, callRepo, destRepo);
+const timeProvider = new TimeProviderSystem();
+
+module.exports = {
+  callRepo,
+  destRepo,
+  elevatorRepo,
+  dispatcher,
+  timeProvider
+};


### PR DESCRIPTION
## Summary
- implement serverless API handlers for calls and ticks
- provide shared container with in-memory repos
- add unit tests for both API handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68871861c9348333a9fe7cb7c535b96f