### PR TITLE
Add integration tests for dispatcher, repositories, and API

### DIFF
--- a/__tests__/api/call.test.js
+++ b/__tests__/api/call.test.js
@@ -39,4 +39,17 @@ describe('api/call', () => {
     await api(req, res);
     expect(res.status).toHaveBeenCalledWith(405);
   });
+
+  test('returns 400 when handler fails', async () => {
+    const exec = jest.fn().mockRejectedValue(new Error('bad'));
+    HandleExternalCall.mockImplementation(() => ({ execute: exec }));
+
+    const req = { method: 'POST', body: JSON.stringify({ floor: 1, direction: 'Up' }), on: jest.fn() };
+    const res = createRes();
+
+    await api(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'bad' });
+  });
 });

--- a/__tests__/api/tick.test.js
+++ b/__tests__/api/tick.test.js
@@ -40,4 +40,30 @@ describe('api/tick', () => {
 
     expect(res.status).toHaveBeenCalledWith(405);
   });
+
+  test('supports GET method', async () => {
+    const exec = jest.fn();
+    HandleTick.mockImplementation(() => ({ execute: exec }));
+
+    const req = { method: 'GET' };
+    const res = createRes();
+
+    await api(req, res);
+
+    expect(exec).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('returns 500 when handler fails', async () => {
+    const exec = jest.fn().mockRejectedValue(new Error('oops'));
+    HandleTick.mockImplementation(() => ({ execute: exec }));
+
+    const req = { method: 'POST' };
+    const res = createRes();
+
+    await api(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'oops' });
+  });
 });

--- a/__tests__/domain/services/ElevatorDispatcher.integration.test.js
+++ b/__tests__/domain/services/ElevatorDispatcher.integration.test.js
@@ -1,0 +1,46 @@
+const ElevatorDispatcher = require('../../../domain/services/ElevatorDispatcher');
+const Elevator = require('../../../domain/entities/Elevator');
+const CallRequest = require('../../../domain/entities/CallRequest');
+const DestinationRequest = require('../../../domain/entities/DestinationRequest');
+const CallRequestRepositoryMemory = require('../../../infrastructure/CallRequestRepositoryMemory');
+const DestinationRequestRepositoryMemory = require('../../../infrastructure/DestinationRequestRepositoryMemory');
+const ElevatorRepositoryHttp = require('../../../infrastructure/ElevatorRepositoryHttp');
+
+// This test uses real repositories to verify dispatcher behaviour with multiple elevators
+
+describe('ElevatorDispatcher integration', () => {
+  test('processes calls and destinations for multiple elevators', async () => {
+    const elevatorRepo = new ElevatorRepositoryHttp([
+      new Elevator('E1', 1),
+      new Elevator('E2', 5)
+    ]);
+    const callRepo = new CallRequestRepositoryMemory();
+    const destRepo = new DestinationRequestRepositoryMemory();
+    const dispatcher = new ElevatorDispatcher(elevatorRepo, callRepo, destRepo);
+
+    await callRepo.enqueue(new CallRequest(4, 'Down'));
+    await destRepo.enqueue(new DestinationRequest(2));
+
+    await dispatcher.handleTick({ now: () => Date.now() });
+
+    let e1 = await elevatorRepo.findById('E1');
+    let e2 = await elevatorRepo.findById('E2');
+    expect(e1.currentFloor.value).toBe(2);
+    expect(e1.state.value).toBe('MovingUp');
+    expect(e1.targetFloors[0].value).toBe(2);
+    expect(e2.currentFloor.value).toBe(4);
+    expect(e2.state.value).toBe('MovingDown');
+    expect(e2.targetFloors[0].value).toBe(4);
+
+    await dispatcher.handleTick({ now: () => Date.now() });
+
+    e1 = await elevatorRepo.findById('E1');
+    e2 = await elevatorRepo.findById('E2');
+    expect(e1.currentFloor.value).toBe(2);
+    expect(e1.state.value).toBe('Loading');
+    expect(e1.targetFloors.length).toBe(0);
+    expect(e2.currentFloor.value).toBe(4);
+    expect(e2.state.value).toBe('Loading');
+    expect(e2.targetFloors.length).toBe(0);
+  });
+});

--- a/__tests__/infrastructure/RepositoryMemory.integration.test.js
+++ b/__tests__/infrastructure/RepositoryMemory.integration.test.js
@@ -1,0 +1,24 @@
+const CallRequestRepositoryMemory = require('../../infrastructure/CallRequestRepositoryMemory');
+const DestinationRequestRepositoryMemory = require('../../infrastructure/DestinationRequestRepositoryMemory');
+const CallRequest = require('../../domain/entities/CallRequest');
+const DestinationRequest = require('../../domain/entities/DestinationRequest');
+
+describe('memory repositories', () => {
+  test('store and clear independent queues', async () => {
+    const callRepo = new CallRequestRepositoryMemory();
+    const destRepo = new DestinationRequestRepositoryMemory();
+
+    await callRepo.enqueue(new CallRequest(1, 'Up'));
+    await destRepo.enqueue(new DestinationRequest(3));
+    await callRepo.enqueue(new CallRequest(2, 'Down'));
+
+    const calls = await callRepo.dequeueAll();
+    const dests = await destRepo.dequeueAll();
+
+    expect(calls.map(c => c.floor.value)).toEqual([1, 2]);
+    expect(dests.map(d => d.floor.value)).toEqual([3]);
+
+    expect(await callRepo.dequeueAll()).toEqual([]);
+    expect(await destRepo.dequeueAll()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- test API endpoints for GET/POST and error paths
- verify dispatcher with real memory repositories and multiple elevators
- ensure memory repositories maintain independent queues

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68941f0358a08333b72bf0c706778675