### PR TITLE
feat: add elevator context and hook

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import ElevatorSimulation from './components/ElevatorSimulation';
+import { ElevatorProvider } from './context/ElevatorContext';
 
 function App() {
-  return <ElevatorSimulation />;
+  return (
+    <ElevatorProvider>
+      <ElevatorSimulation />
+    </ElevatorProvider>
+  );
 }
 
 export default App;

--- a/src/components/ElevatorSimulation.js
+++ b/src/components/ElevatorSimulation.js
@@ -1,7 +1,18 @@
 import React from 'react';
+import { useElevator } from '../context/ElevatorContext';
 
 function ElevatorSimulation() {
-  return <div>Elevator Simulation Component</div>;
+  const { elevators } = useElevator();
+
+  return (
+    <div>
+      {elevators.map(e => (
+        <div key={e.id}>
+          Elevator {e.id}: floor {e.currentFloor} — state {e.state}
+        </div>
+      ))}
+    </div>
+  );
 }
 
 export default ElevatorSimulation;

--- a/src/context/ElevatorContext.js
+++ b/src/context/ElevatorContext.js
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const ElevatorContext = createContext();
+
+const initialElevators = [
+  { id: 1, currentFloor: 1, targetFloors: [], state: 'Idle' },
+  { id: 2, currentFloor: 1, targetFloors: [], state: 'Idle' },
+  { id: 3, currentFloor: 1, targetFloors: [], state: 'Idle' }
+];
+
+export const ElevatorProvider = ({ children }) => {
+  const [elevators, setElevators] = useState(initialElevators);
+
+  const callElevator = (floor, _direction) => {
+    setElevators(prev => {
+      const best = prev.reduce((prevElevator, curr) => {
+        const prevDist = Math.abs(prevElevator.currentFloor - floor);
+        const currDist = Math.abs(curr.currentFloor - floor);
+        return currDist < prevDist ? curr : prevElevator;
+      }, prev[0]);
+
+      return prev.map(e =>
+        e.id === best.id
+          ? {
+              ...e,
+              targetFloors: e.targetFloors.includes(floor)
+                ? e.targetFloors
+                : [...e.targetFloors, floor]
+            }
+          : e
+      );
+    });
+  };
+
+  const selectDestination = (elevatorId, floor) => {
+    setElevators(prev =>
+      prev.map(e =>
+        e.id === elevatorId
+          ? {
+              ...e,
+              targetFloors: e.targetFloors.includes(floor)
+                ? e.targetFloors
+                : [...e.targetFloors, floor]
+            }
+          : e
+      )
+    );
+  };
+
+  return (
+    <ElevatorContext.Provider value={{ elevators, callElevator, selectDestination }}>
+      {children}
+    </ElevatorContext.Provider>
+  );
+};
+
+export const useElevator = () => {
+  const ctx = useContext(ElevatorContext);
+  if (!ctx) {
+    throw new Error('useElevator must be used within an ElevatorProvider');
+  }
+  return ctx;
+};
+
+export default ElevatorContext;


### PR DESCRIPTION
## Summary
- manage elevator state through React context with call and destination helpers
- expose `useElevator` hook and wrap app with context provider
- display elevator state via new context in simulation component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689421b7c6608333b8b511861385fce5