### PR TITLE
feat: reduce elevators to two

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Una prueba de concepto académica que implementa una metodología ágil OO-Clean-DDD de principio a fin.
 
+La simulación actual modela **dos ascensores (A1 y A2)** en un edificio de cinco pisos.
+
 ## Frontend
 - **React.js (ES6+)** con componentes reutilizables, hooks y Context API.
 

--- a/__tests__/application/HandleTick.test.js
+++ b/__tests__/application/HandleTick.test.js
@@ -3,7 +3,7 @@ const Elevator = require('../../domain/entities/Elevator');
 
 describe('HandleTick', () => {
   test('delegates tick to dispatcher and publishes elevator updates', async () => {
-    const elevator = new Elevator('E1');
+    const elevator = new Elevator('A1');
     const elevatorRepo = { findAll: jest.fn().mockResolvedValue([elevator]) };
     const dispatcher = { handleTick: jest.fn(), elevatorRepo };
     const publisher = { publish: jest.fn() };

--- a/__tests__/components/ElevatorSimulation.test.js
+++ b/__tests__/components/ElevatorSimulation.test.js
@@ -13,7 +13,8 @@ it('renders floors and elevators', () => {
     </ElevatorProvider>
   );
   expect(screen.getByText('Floor 1')).toBeInTheDocument();
-  expect(screen.getByText('Elev 1')).toBeInTheDocument();
+  expect(screen.getByText('Elev A1')).toBeInTheDocument();
+  expect(screen.getByText('Elev A2')).toBeInTheDocument();
 });
 
 // Test callElevator integrates with API and updates context
@@ -42,7 +43,7 @@ it('selectDestination updates targets and tick calls API', async () => {
   const { result } = renderHook(() => useElevator(), { wrapper: ElevatorProvider });
 
   await act(async () => {
-    await result.current.selectDestination(1, 2);
+    await result.current.selectDestination('A1', 2);
   });
   expect(result.current.elevators[0].targetFloors).toContain(2);
 

--- a/__tests__/domain/entities/Building.test.js
+++ b/__tests__/domain/entities/Building.test.js
@@ -6,8 +6,8 @@ const ElevatorState = require('../../../domain/valueobjects/ElevatorState');
 
 describe('Building', () => {
   test('assigns call to closest elevator considering direction', () => {
-    const e1 = new Elevator('E1', 1);
-    const e2 = new Elevator('E2', 5);
+    const e1 = new Elevator('A1', 1);
+    const e2 = new Elevator('A2', 5);
     e1.state = new ElevatorState('Idle');
     e2.state = new ElevatorState('Idle');
     const building = new Building([e1, e2]);
@@ -19,8 +19,8 @@ describe('Building', () => {
   });
 
   test('assigns destination to nearest elevator', () => {
-    const e1 = new Elevator('E1', 1);
-    const e2 = new Elevator('E2', 5);
+    const e1 = new Elevator('A1', 1);
+    const e2 = new Elevator('A2', 5);
     const building = new Building([e1, e2]);
 
     building.handleDestination(new DestinationRequest(2));

--- a/__tests__/domain/entities/Elevator.test.js
+++ b/__tests__/domain/entities/Elevator.test.js
@@ -3,7 +3,7 @@ const FloorNumber = require('../../../domain/valueobjects/FloorNumber');
 
 describe('Elevator', () => {
   test('addDestination adds unique floors', () => {
-    const e = new Elevator('E1');
+    const e = new Elevator('A1');
     e.addDestination(3);
     expect(e.targetFloors).toHaveLength(1);
     expect(e.targetFloors[0]).toBeInstanceOf(FloorNumber);
@@ -13,14 +13,14 @@ describe('Elevator', () => {
   });
 
   test('move with no destinations sets Idle state', () => {
-    const e = new Elevator('E1');
+    const e = new Elevator('A1');
     e.move();
     expect(e.currentFloor.value).toBe(1);
     expect(e.state.value).toBe('Idle');
   });
 
   test('move up increments floor and sets MovingUp', () => {
-    const e = new Elevator('E1');
+    const e = new Elevator('A1');
     e.addDestination(3);
     e.move();
     expect(e.currentFloor.value).toBe(2);
@@ -28,7 +28,7 @@ describe('Elevator', () => {
   });
 
   test('move down decrements floor and sets MovingDown', () => {
-    const e = new Elevator('E1', 3);
+    const e = new Elevator('A1', 3);
     e.addDestination(1);
     e.move();
     expect(e.currentFloor.value).toBe(2);
@@ -36,7 +36,7 @@ describe('Elevator', () => {
   });
 
   test('arriving at destination sets Loading and removes target', () => {
-    const e = new Elevator('E1', 1);
+    const e = new Elevator('A1', 1);
     e.addDestination(1);
     e.move();
     expect(e.currentFloor.value).toBe(1);

--- a/__tests__/domain/services/ElevatorDispatcher.integration.test.js
+++ b/__tests__/domain/services/ElevatorDispatcher.integration.test.js
@@ -11,8 +11,8 @@ const ElevatorRepositoryHttp = require('../../../infrastructure/ElevatorReposito
 describe('ElevatorDispatcher integration', () => {
   test('processes calls and destinations for multiple elevators', async () => {
     const elevatorRepo = new ElevatorRepositoryHttp([
-      new Elevator('E1', 1),
-      new Elevator('E2', 5)
+      new Elevator('A1', 1),
+      new Elevator('A2', 5)
     ]);
     const callRepo = new CallRequestRepositoryMemory();
     const destRepo = new DestinationRequestRepositoryMemory();
@@ -23,8 +23,8 @@ describe('ElevatorDispatcher integration', () => {
 
     await dispatcher.handleTick({ now: () => Date.now() });
 
-    let e1 = await elevatorRepo.findById('E1');
-    let e2 = await elevatorRepo.findById('E2');
+    let e1 = await elevatorRepo.findById('A1');
+    let e2 = await elevatorRepo.findById('A2');
     expect(e1.currentFloor.value).toBe(2);
     expect(e1.state.value).toBe('MovingUp');
     expect(e1.targetFloors[0].value).toBe(2);
@@ -34,8 +34,8 @@ describe('ElevatorDispatcher integration', () => {
 
     await dispatcher.handleTick({ now: () => Date.now() });
 
-    e1 = await elevatorRepo.findById('E1');
-    e2 = await elevatorRepo.findById('E2');
+    e1 = await elevatorRepo.findById('A1');
+    e2 = await elevatorRepo.findById('A2');
     expect(e1.currentFloor.value).toBe(2);
     expect(e1.state.value).toBe('Loading');
     expect(e1.targetFloors.length).toBe(0);

--- a/__tests__/domain/services/ElevatorDispatcher.multi.test.js
+++ b/__tests__/domain/services/ElevatorDispatcher.multi.test.js
@@ -6,8 +6,8 @@ const ElevatorState = require('../../../domain/valueobjects/ElevatorState');
 
 describe('ElevatorDispatcher with multiple elevators', () => {
   test('dispatches requests to nearest elevators', async () => {
-    const e1 = new Elevator('E1', 1);
-    const e2 = new Elevator('E2', 5);
+    const e1 = new Elevator('A1', 1);
+    const e2 = new Elevator('A2', 5);
     e1.state = new ElevatorState('Idle');
     e2.state = new ElevatorState('Idle');
 

--- a/__tests__/domain/services/ElevatorDispatcher.test.js
+++ b/__tests__/domain/services/ElevatorDispatcher.test.js
@@ -38,7 +38,7 @@ describe('ElevatorDispatcher', () => {
   });
 
   test('handleTick moves elevators and saves state', async () => {
-    const elevator = new Elevator('E1');
+    const elevator = new Elevator('A1');
     elevatorRepo.findAll.mockResolvedValue([elevator]);
     callRepo.dequeueAll.mockResolvedValue([]);
     destRepo.dequeueAll.mockResolvedValue([]);

--- a/__tests__/infrastructure/ElevatorRepositoryHttp.test.js
+++ b/__tests__/infrastructure/ElevatorRepositoryHttp.test.js
@@ -9,13 +9,13 @@ describe('ElevatorRepositoryHttp', () => {
 
   test('can save and retrieve elevators', async () => {
     const repo = new ElevatorRepositoryHttp();
-    const e1 = { id: 'E1' };
-    const e2 = { id: 'E2' };
+    const e1 = { id: 'A1' };
+    const e2 = { id: 'A2' };
     await repo.save(e1);
     await repo.save(e2);
     const all = await repo.findAll();
     expect(all).toEqual([e1, e2]);
-    const found = await repo.findById('E1');
+    const found = await repo.findById('A1');
     expect(found).toBe(e1);
   });
 });

--- a/infrastructure/container.js
+++ b/infrastructure/container.js
@@ -9,8 +9,8 @@ const TimeProviderSystem = require('./TimeProviderSystem');
 const callRepo = new CallRequestRepositoryMemory();
 const destRepo = new DestinationRequestRepositoryMemory();
 const elevatorRepo = new ElevatorRepositoryHttp([
-  new Elevator('E1', 1),
-  new Elevator('E2', 5)
+  new Elevator('A1', 1),
+  new Elevator('A2', 5)
 ]);
 
 const dispatcher = new ElevatorDispatcher(elevatorRepo, callRepo, destRepo);

--- a/src/components/ElevatorSimulation.js
+++ b/src/components/ElevatorSimulation.js
@@ -40,14 +40,14 @@ function ElevatorSimulation() {
             className="position-relative border"
             style={{ height: FLOOR_COUNT * FLOOR_HEIGHT }}
           >
-            {elevators.map(e => (
+            {elevators.map((e, i) => (
               <div
                 key={e.id}
                 className="bg-primary text-white p-2 rounded position-absolute"
                 style={{
                   width: 80,
                   height: FLOOR_HEIGHT - 10,
-                  left: (e.id - 1) * 100,
+                  left: i * 100,
                   transition: 'top 1s linear',
                   top: (FLOOR_COUNT - e.currentFloor) * FLOOR_HEIGHT,
                 }}

--- a/src/context/ElevatorContext.js
+++ b/src/context/ElevatorContext.js
@@ -3,9 +3,8 @@ import React, { createContext, useContext, useState, useCallback } from 'react';
 const ElevatorContext = createContext();
 
 const initialElevators = [
-  { id: 1, currentFloor: 1, targetFloors: [], state: 'Idle' },
-  { id: 2, currentFloor: 1, targetFloors: [], state: 'Idle' },
-  { id: 3, currentFloor: 1, targetFloors: [], state: 'Idle' }
+  { id: 'A1', currentFloor: 1, targetFloors: [], state: 'Idle' },
+  { id: 'A2', currentFloor: 1, targetFloors: [], state: 'Idle' },
 ];
 
 export const ElevatorProvider = ({ children }) => {


### PR DESCRIPTION
## Summary
- limit simulation to two elevators A1/A2
- update context, UI and infrastructure for new IDs
- adjust unit tests across layers for two elevators

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68942a120b5c8333bb6f087cb8832067