### PR TITLE
Limit call buttons on top and bottom floors

### DIFF
--- a/__tests__/components/ElevatorSimulation.test.js
+++ b/__tests__/components/ElevatorSimulation.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen, renderHook, act } from '@testing-library/react';
+import { render, screen, renderHook, act, within } from '@testing-library/react';
 import ElevatorSimulation from '../../src/components/ElevatorSimulation';
 import { ElevatorProvider, useElevator } from '../../src/context/ElevatorContext';
 
@@ -15,6 +15,25 @@ it('renders floors and elevators', () => {
   expect(screen.getByText('Floor 1')).toBeInTheDocument();
   expect(screen.getByText('Elev A1')).toBeInTheDocument();
   expect(screen.getByText('Elev A2')).toBeInTheDocument();
+});
+
+it('renders appropriate call buttons on each floor', () => {
+  render(
+    <ElevatorProvider>
+      <ElevatorSimulation />
+    </ElevatorProvider>
+  );
+
+  const floor1 = within(screen.getByText('Floor 1').parentElement).getAllByRole('button');
+  expect(floor1).toHaveLength(1);
+  expect(floor1[0].querySelector('.fa-arrow-up')).toBeInTheDocument();
+
+  const floor3 = within(screen.getByText('Floor 3').parentElement).getAllByRole('button');
+  expect(floor3).toHaveLength(2);
+
+  const floor5 = within(screen.getByText('Floor 5').parentElement).getAllByRole('button');
+  expect(floor5).toHaveLength(1);
+  expect(floor5[0].querySelector('.fa-arrow-down')).toBeInTheDocument();
 });
 
 // Test callElevator integrates with API and updates context

--- a/src/components/FloorButton.js
+++ b/src/components/FloorButton.js
@@ -7,20 +7,24 @@ function FloorButton({ floor }) {
 
   return (
     <div className="btn-group">
-      <Button
-        size="sm"
-        variant="outline-primary"
-        onClick={() => callElevator(floor, 'Up')}
-      >
-        <i className="fa-solid fa-arrow-up"></i>
-      </Button>
-      <Button
-        size="sm"
-        variant="outline-primary"
-        onClick={() => callElevator(floor, 'Down')}
-      >
-        <i className="fa-solid fa-arrow-down"></i>
-      </Button>
+      {floor !== 5 && (
+        <Button
+          size="sm"
+          variant="outline-primary"
+          onClick={() => callElevator(floor, 'Up')}
+        >
+          <i className="fa-solid fa-arrow-up"></i>
+        </Button>
+      )}
+      {floor !== 1 && (
+        <Button
+          size="sm"
+          variant="outline-primary"
+          onClick={() => callElevator(floor, 'Down')}
+        >
+          <i className="fa-solid fa-arrow-down"></i>
+        </Button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Render only an Up button on floor 1 and only a Down button on floor 5
- Add tests to ensure correct call buttons per floor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894375f40188333b5aec260834cf012