### PR TITLE
Prefer idle elevators for new calls

### DIFF
--- a/__tests__/domain/entities/Building.test.js
+++ b/__tests__/domain/entities/Building.test.js
@@ -28,4 +28,17 @@ describe('Building', () => {
     expect(e1.targetFloors[0].value).toBe(2);
     expect(e2.targetFloors).toHaveLength(0);
   });
+
+  test('prefers elevator with empty queue for new call', () => {
+    const e1 = new Elevator('A1', 1);
+    const e2 = new Elevator('A2', 1);
+    const building = new Building([e1, e2]);
+
+    building.handleDestination(new DestinationRequest(5));
+
+    building.handleCall(new CallRequest(3, 'Up'));
+
+    expect(e1.targetFloors.map(f => f.value)).toEqual([5]);
+    expect(e2.targetFloors[0].value).toBe(3);
+  });
 });

--- a/domain/entities/Building.js
+++ b/domain/entities/Building.js
@@ -35,6 +35,10 @@ class Building {
         }
       }
 
+      if (elevator.targetFloors.length > 0 || state !== 'Idle') {
+        score += 1000;
+      }
+
       if (score < bestScore) {
         bestScore = score;
         best = elevator;


### PR DESCRIPTION
## Summary
- Penalize elevators that are busy or moving when selecting the best elevator for a call
- Add unit test to ensure idle elevator with empty queue is chosen over a busy one

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894445720b883339ae2bde8d1ca54ff