### PR TITLE
Prioritize in-cab destinations over external calls

### DIFF
--- a/__tests__/domain/services/ElevatorDispatcher.multi.test.js
+++ b/__tests__/domain/services/ElevatorDispatcher.multi.test.js
@@ -35,4 +35,35 @@ describe('ElevatorDispatcher with multiple elevators', () => {
     expect(elevatorRepo.save).toHaveBeenCalledWith(e1);
     expect(elevatorRepo.save).toHaveBeenCalledWith(e2);
   });
+
+  test('prioritizes in-elevator destination over external call', async () => {
+    const e1 = new Elevator('A1', 1);
+    const e2 = new Elevator('A2', 5);
+    e1.state = new ElevatorState('Idle');
+    e2.state = new ElevatorState('Idle');
+
+    const elevatorRepo = {
+      findAll: jest.fn().mockResolvedValue([e1, e2]),
+      save: jest.fn(),
+    };
+
+    const callRepo = {
+      dequeueAll: jest.fn().mockResolvedValue([new CallRequest(2, 'Up')]),
+      enqueue: jest.fn(),
+    };
+
+    const destRepo = {
+      dequeueAll: jest.fn().mockResolvedValue([new DestinationRequest(3)]),
+      enqueue: jest.fn(),
+    };
+
+    const dispatcher = new ElevatorDispatcher(elevatorRepo, callRepo, destRepo);
+
+    await dispatcher.handleTick({ now: () => Date.now() });
+
+    expect(e1.targetFloors[0].value).toBe(3);
+    expect(e2.targetFloors[0].value).toBe(2);
+    expect(elevatorRepo.save).toHaveBeenCalledWith(e1);
+    expect(elevatorRepo.save).toHaveBeenCalledWith(e2);
+  });
 });

--- a/domain/services/ElevatorDispatcher.js
+++ b/domain/services/ElevatorDispatcher.js
@@ -18,15 +18,14 @@ class ElevatorDispatcher {
   async handleTick(timeProvider) {
     const elevators = await this.elevatorRepo.findAll();
     const building = new Building(elevators);
-    const calls = await this.callRepo.dequeueAll();
     const destinations = await this.destRepo.dequeueAll();
-
-    for (const call of calls) {
-      building.handleCall(call);
-    }
-
     for (const dest of destinations) {
       building.handleDestination(dest);
+    }
+
+    const calls = await this.callRepo.dequeueAll();
+    for (const call of calls) {
+      building.handleCall(call);
     }
 
     for (const elevator of building.getElevators()) {


### PR DESCRIPTION
## Summary
- Handle destination requests before external calls in the dispatcher
- Add regression test ensuring a passenger's destination isn't overridden by new calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894457141f48333be41fd8f1b6023a3